### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/unixfox/mcbin.png?label=ready&title=Ready)](https://waffle.io/unixfox/mcbin)
 ![ComputerCraft](http://www.computercraft.info/wiki/images/d/da/Ccblink.gif)
 [MCBin](http://mcbin.unixfox.eu/) [![Build Status](https://travis-ci.org/unixfox/MCBin.svg?branch=master)](https://travis-ci.org/unixfox/MCBin)
 ==============================


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/unixfox/mcbin

This was requested by a real person (user unixfox) on waffle.io, we're not trying to spam you.